### PR TITLE
fix: IPv6 rfc3986 compliancy

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const reduceValue = (_, v) => v
 const Reducers = {
   ip4: reduceValue,
   ip6: (str, content, i, parts) => (
-    parts.some(p => ['tcp', 'udp', 'http', 'https', 'ws', 'wss'].includes(p.protocol))
-      ? `[${content}]`
-      : content
+    parts.length === 1 && parts[0].protocol === 'ip6'
+      ? content
+      : `[${content}]`
   ),
   tcp: (str, content, i, parts) => (
     parts.some(p => ['http', 'https', 'ws', 'wss'].includes(p.protocol))

--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ const reduceValue = (_, v) => v
 
 const Reducers = {
   ip4: reduceValue,
-  ip6: reduceValue,
+  ip6: (str, content, i, parts) => (
+    parts.some(p => ['tcp', 'udp', 'http', 'https', 'ws', 'wss'].includes(p.protocol))
+      ? `[${content}]`
+      : content
+  ),
   tcp: (str, content, i, parts) => (
     parts.some(p => ['http', 'https', 'ws', 'wss'].includes(p.protocol))
       ? `${str}:${content}`

--- a/test.js
+++ b/test.js
@@ -6,13 +6,13 @@ test('should convert multiaddr to URI', (t) => {
     ['/ip4/127.0.0.1', '127.0.0.1'],
     ['/ip4/127.0.0.1/http', 'http://127.0.0.1'],
     ['/ip6/fc00::', 'fc00::'],
-    ['/ip6/fc00::/http', 'http://fc00::'],
+    ['/ip6/fc00::/http', 'http://[fc00::]'],
     ['/ip4/0.0.7.6/tcp/1234', 'tcp://0.0.7.6:1234'],
     ['/ip4/0.0.7.6/tcp/1234/http', 'http://0.0.7.6:1234'],
     ['/ip4/0.0.7.6/tcp/1234/https', 'https://0.0.7.6:1234'],
-    ['/ip6/::/tcp/0', 'tcp://:::0'],
+    ['/ip6/::/tcp/0', 'tcp://[::]:0'],
     ['/ip4/0.0.7.6/udp/1234', 'udp://0.0.7.6:1234'],
-    ['/ip6/::/udp/0', 'udp://:::0'],
+    ['/ip6/::/udp/0', 'udp://[::]:0'],
     ['/dnsaddr/ipfs.io', 'ipfs.io'],
     ['/dns4/ipfs.io', 'ipfs.io'],
     ['/dns4/libp2p.io', 'libp2p.io'],
@@ -26,10 +26,10 @@ test('should convert multiaddr to URI', (t) => {
     ['/dnsaddr/ipfs.io/http', 'http://ipfs.io'],
     ['/dnsaddr/ipfs.io/https', 'https://ipfs.io'],
     ['/ip4/1.2.3.4/tcp/3456/ws', 'ws://1.2.3.4:3456'],
-    ['/ip6/::/tcp/0/ws', 'ws://:::0'],
+    ['/ip6/::/tcp/0/ws', 'ws://[::]:0'],
     ['/dnsaddr/ipfs.io/wss', 'wss://ipfs.io'],
     ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
-    ['/ip6/::/tcp/0/wss', 'wss://:::0'],
+    ['/ip6/::/tcp/0/wss', 'wss://[::]:0'],
     [
       '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo',
       'ws://1.2.3.4:3456/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo'
@@ -44,16 +44,16 @@ test('should convert multiaddr to URI', (t) => {
     ],
     [
       '/ip6/::/tcp/0/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5',
-      'ws://:::0/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5'
+      'ws://[::]:0/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5'
     ],
     [
       '/dns4/wrtc-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
       'wss://wrtc-star.discovery.libp2p.io:443/p2p-webrtc-star/ipfs/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
     ],
     ['/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct', 'http://1.2.3.4:3456/p2p-webrtc-direct'],
-    ['/ip6/::/tcp/0/http/p2p-webrtc-direct', 'http://:::0/p2p-webrtc-direct'],
+    ['/ip6/::/tcp/0/http/p2p-webrtc-direct', 'http://[::]:0/p2p-webrtc-direct'],
     ['/ip4/1.2.3.4/tcp/3456/ws/p2p-websocket-star', 'ws://1.2.3.4:3456/p2p-websocket-star'],
-    ['/ip6/::/tcp/0/ws/p2p-websocket-star', 'ws://:::0/p2p-websocket-star'],
+    ['/ip6/::/tcp/0/ws/p2p-websocket-star', 'ws://[::]:0/p2p-websocket-star'],
     [
       '/dnsaddr/localhost/ws/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
       'ws://localhost/p2p-websocket-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'


### PR DESCRIPTION
The square brackets were missing for IPv6 URIs. Hence someone using it couldn't just copy and paste it in a browser's URL bar for example.

We just don't enclose it if it's an IPv6 literal.

Source: https://tools.ietf.org/html/rfc3986#section-3.2.2
Ref.: https://github.com/ipfs-shipyard/ipfs-webui/issues/932